### PR TITLE
MAD-410: Don't rely on windows headers

### DIFF
--- a/mxpeg-decoder/mxpeg-decoder.cpp
+++ b/mxpeg-decoder/mxpeg-decoder.cpp
@@ -265,7 +265,7 @@ __declspec(dllexport) void * mxpeg_decoder_init()
 	return (void *)p;
 }
 
-__declspec(dllexport) DecodedFrameInfo mxpeg_decoder_decode(void * pObject,BYTE * pIn,int len,BYTE * pOut,int * outlen)
+__declspec(dllexport) DecodedFrameInfo mxpeg_decoder_decode(void * pObject, unsigned char * pIn,int len, unsigned char * pOut,int * outlen)
 {
 	CMxpegDecode * p = (CMxpegDecode*)pObject;
 	p->DecodeMxpeg(pIn,len,pOut,outlen);

--- a/mxpeg-decoder/mxpeg-decoder.cpp
+++ b/mxpeg-decoder/mxpeg-decoder.cpp
@@ -166,7 +166,7 @@ public:
 	CMxpegDecode(){};
 	~CMxpegDecode(){};
 
-	void DecodeMxpeg(BYTE * pIn,int len,BYTE * pOut,int * outlen) ;
+	void DecodeMxpeg(unsigned char * pIn, int len, unsigned char * pOut, int * outlen) ;
 	void UnInitMxpeg() ;
 	void InitMxpeg();
 	// Assumes both pointers are valid.
@@ -176,7 +176,7 @@ protected:
 	mx::IFileWriter *writer;
 };
 
-void CMxpegDecode::DecodeMxpeg(BYTE * pIn, int len, BYTE * pOut, int * outlen) 
+void CMxpegDecode::DecodeMxpeg(unsigned char * pIn, int len, unsigned char * pOut, int * outlen) 
 {
 	mxm::sendStatusMessage(mxm::DebugMessage, mxmString("Decode"));
 

--- a/mxpeg-decoder/mxpeg-decoder.h
+++ b/mxpeg-decoder/mxpeg-decoder.h
@@ -7,7 +7,6 @@ extern "C"
     };
 
     __declspec(dllexport) void *mxpeg_decoder_init();
-
     __declspec(dllexport) DecodedFrameInfo mxpeg_decoder_decode(void *pObject, unsigned char *pIn, int len, unsigned char *pOut, int *outlen);
     __declspec(dllexport) void mxpeg_decoder_deinit(void *pObject);
 }

--- a/mxpeg-decoder/mxpeg-decoder.h
+++ b/mxpeg-decoder/mxpeg-decoder.h
@@ -8,6 +8,6 @@ extern "C"
 
     __declspec(dllexport) void *mxpeg_decoder_init();
 
-    __declspec(dllexport) DecodedFrameInfo mxpeg_decoder_decode(void *pObject, BYTE *pIn, int len, BYTE *pOut, int *outlen);
+    __declspec(dllexport) DecodedFrameInfo mxpeg_decoder_decode(void *pObject, unsigned char *pIn, int len, unsigned char *pOut, int *outlen);
     __declspec(dllexport) void mxpeg_decoder_deinit(void *pObject);
 }

--- a/mxpeg-decoder/mxpeg-decoder.h
+++ b/mxpeg-decoder/mxpeg-decoder.h
@@ -3,7 +3,7 @@ extern "C"
 {
     struct DecodedFrameInfo {
         int height = 0;
-        int width = 0;    
+        int width = 0;
     };
 
     __declspec(dllexport) void *mxpeg_decoder_init();


### PR DESCRIPTION
- The underlying API call takes a `unsigned char*` anyway so there's no reason to use `BYTE*` in the external API